### PR TITLE
Revert "guacamole: Exclude lineage SystemUI overlays from RRO"

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -14,9 +14,6 @@ DEVICE_PACKAGE_OVERLAYS += \
     $(LOCAL_PATH)/overlay \
     $(LOCAL_PATH)/overlay-lineage
 
-PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += \
-    $(LOCAL_PATH)/overlay-lineage/frameworks/base/packages/SystemUI
-
 # Audio
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/mixer_paths_11811.xml:$(TARGET_COPY_OUT_VENDOR)/etc/mixer_paths_11811.xml \


### PR DESCRIPTION
This reverts commit 6b29fc69e57adc2426fc396f259690b446aae92c.

Change-Id: I0df7de87ea01d5c714aa70243d0432600b371420